### PR TITLE
Allow installing Raven with a wider range of dependencies.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,12 +21,12 @@
     ],
     "require": {
         "php": "^8.1.0",
-        "league/openapi-psr7-validator": "^0.18.0",
+        "league/openapi-psr7-validator": "^0.17|^0.18",
         "cebe/php-openapi": "^1.7",
         "psr/http-message": "^1.0",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
-        "psr/log": "^3.0",
+        "psr/log": "^1.0|^2.0|^3.0",
         "fakerphp/faker": "^1.20"
     },
     "require-dev": {


### PR DESCRIPTION
Working on issue #16.

I'm allowing a more open range of version since Raven code is aleady compatible with them.