### PR TITLE
bridge: Fix error when request URI matches multiples API operations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- When an URI matches multiple API operations (example: `/api/path` and `/api/{pattern}`)
+  the `ResponseValidator` was looping over each and tried to validate the `ResponseInterface`
+  body with the definition. Now the `ResponseValidator` will only validates against
+  a single matching operation. If no operation matches, an error will be thrown.
+  That last point wasn't caught before.
 
 ## [v0.2.0] - 2022-10-29
 ### Changed

--- a/src/Bridge/LeagueOpenAPIValidation/ResponseValidator.php
+++ b/src/Bridge/LeagueOpenAPIValidation/ResponseValidator.php
@@ -3,9 +3,11 @@
 namespace CHStudio\Raven\Bridge\LeagueOpenAPIValidation;
 
 use CHStudio\Raven\Bridge\LeagueOpenAPIValidation\Exception\ValidationExceptionMapper;
+use CHStudio\Raven\Validator\Exception\OperationNotFoundException;
 use CHStudio\Raven\Validator\Exception\ResponseNotExpectedException;
 use CHStudio\Raven\Validator\ResponseValidatorInterface;
 use League\OpenAPIValidation\PSR7\Exception\NoResponseCode;
+use League\OpenAPIValidation\PSR7\OperationAddress;
 use League\OpenAPIValidation\PSR7\PathFinder;
 use League\OpenAPIValidation\PSR7\ResponseValidator as LeagueResponseValidator;
 use Psr\Http\Message\RequestInterface;
@@ -22,15 +24,10 @@ class ResponseValidator implements ResponseValidatorInterface
     public function validate(ResponseInterface $input, RequestInterface $request): void
     {
         try {
-            $pathFinder = new PathFinder(
-                $this->adapted->getSchema(),
-                $request->getUri(),
-                $request->getMethod()
+            $this->adapted->validate(
+                $this->findOperation($request),
+                $input
             );
-
-            foreach ($pathFinder->search() as $operation) {
-                $this->adapted->validate($operation, $input);
-            }
         } catch (NoResponseCode $e) {
             throw new ResponseNotExpectedException($request, $input, $e);
         } catch (\Throwable $e) {
@@ -46,5 +43,32 @@ class ResponseValidator implements ResponseValidatorInterface
             }
             throw $e;
         }
+    }
+
+    /**
+     * Find the best OperationAdress to use to validate the current response
+     */
+    private function findOperation(RequestInterface $request): OperationAddress
+    {
+        $pathFinder = new PathFinder(
+            $this->adapted->getSchema(),
+            $request->getUri(),
+            $request->getMethod()
+        );
+
+        $operations = $pathFinder->search();
+        if (\count($operations) === 0) {
+            throw new OperationNotFoundException($request);
+        }
+
+        foreach ($operations as $operation) {
+            //If we got an exact path match, we use the current Operation
+            if ($operation->path() === $request->getUri()->getPath()) {
+                return $operation;
+            }
+        }
+
+        //If we haven't an exact match, use the first in the list
+        return $operations[0];
     }
 }

--- a/src/Validator/Exception/OperationNotFoundException.php
+++ b/src/Validator/Exception/OperationNotFoundException.php
@@ -10,7 +10,7 @@ class OperationNotFoundException extends RuntimeException implements ValidationE
 {
     public function __construct(
         public readonly RequestInterface $request,
-        Throwable $previous
+        Throwable $previous = null
     ) {
         $message = sprintf(
             'API operation for request [%s] %s hasn\'t been found.',


### PR DESCRIPTION
Since it's possible to have multiple API operations that matches a given URI (path with pattern + path without that have the same structure), we need to ensure that the response will only be validated against a single Operation.

Fix #21